### PR TITLE
Update amqp dependency to 0.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easter",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Amqp/Http pub/sub client for RabbitMQ",
   "homepage": "http://github.com/topliceanu/easter",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "doc": "./node_modules/.bin/codo src"
   },
   "dependencies": {
-    "amqp": "0.2.0",
+    "amqp": "0.2.6",
     "backoff": "2.4.1",
     "q": "1.1.2",
     "request": "2.51.0",


### PR DESCRIPTION
Description
-----------
- Updates amqp dependency to the latest.

Tests
-----
- `npm run test` [2017-01-17-easter-test.txt](https://github.com/topliceanu/easter/files/712140/2017-01-17-easter-test.txt)

- `npm run coverage` did pass with 94%.
- `npm run lint` had a few outstanding issues with maximum allowed length width:

```
root@homestead:/home/vagrant/Code/halogen/easter# npm run lint

> easter@0.0.1 lint /home/vagrant/Code/halogen/easter
> coffeelint ./src

  ✓ ./src/Client.coffee
  ✓ ./src/index.coffee
  ✗ ./src/RabbitAmqpClient.coffee
     ✗ #98: Line exceeds maximum allowed length. Length is 166, max is 120.
     ✗ #99: Line exceeds maximum allowed length. Length is 174, max is 120.
     ✗ #101: Line exceeds maximum allowed length. Length is 163, max is 120.
     ✗ #122: Line exceeds maximum allowed length. Length is 136, max is 120.
     ✗ #144: Line exceeds maximum allowed length. Length is 175, max is 120.
  ✗ ./src/RabbitHttpClient.coffee
     ✗ #113: Line exceeds maximum allowed length. Length is 142, max is 120.
  ✗ ./src/util.coffee
     ✗ #15: Line exceeds maximum allowed length. Length is 143, max is 120.
     ✗ #47: Line exceeds maximum allowed length. Length is 146, max is 120.

✗ Lint! » 8 errors and 0 warnings in 5 files
```

We can address this in a new PR.

Questions
----------
- Does this require a version bump? 0.0.2 or 1.0.0 since its being used on a production application?
- Do we want to wait and resolve the above lint issues before bumping the version for next release?

Thanks!

Resolves #4 


